### PR TITLE
add explainer for Homebrew users

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ See the examples in the
 [Scripts](https://github.com/kristopherjohnson/MenubarCountdown/tree/master/Scripts)
 directory for details.
 
-Releases are available from [the Mac App Store](https://apps.apple.com/us/app/menubar-countdown/id1485343244?mt=12)
-or <https://github.com/kristopherjohnson/MenubarCountdown/releases>.
+Releases are available from:
+- The [Mac App Store](https://apps.apple.com/us/app/menubar-countdown/id1485343244?mt=12)
+- <https://github.com/kristopherjohnson/MenubarCountdown/releases>
+- [Homebrew](https://formulae.brew.sh/cask/menubar-countdown) (e.g. `brew install cask menubar-countdown`)
 
 <a href="https://apps.apple.com/us/app/menubar-countdown/id1485343244?mt=12"><img src="https://undefinedvalue.s3.amazonaws.com/Download_on_the_Mac_App_Store_Badge_US-UK_RGB.svg" alt="Download on the Mac App Store"></a>
 


### PR DESCRIPTION
Useful little app, thanks!

I recently discovered MenubarCountdown and wanted to try it out. When available, I tend to look at READMEs first, saw the App Store link and first installed that way.

However since I prefer not to depend on the App Store, especially for open source projects, I was pleasantly surprised to learn after installing that it's available on Homebrew.

Thus the intention of this simple README PR is to improve discoverability for other Homebrew-preferring Mac users.