### PR TITLE
added quick start 25 minutes menu item

### DIFF
--- a/MenubarCountdown/AppDelegate.swift
+++ b/MenubarCountdown/AppDelegate.swift
@@ -288,7 +288,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         timerExpiredAlertController?.showAlert()
     }
 
-
     // MARK: Menu item and button event handlers
 
     /**
@@ -359,8 +358,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if let startTimerDialogController = startTimerDialogController {
             startTimerDialogController.dismissDialog(sender)
         }
-
         timerSettingSeconds = (startHours * 3600) + (startMinutes * 60) + startSeconds
+        internalStart()
+    }
+
+    func internalStart() {
         secondsRemaining = timerSettingSeconds
 
         isTimerRunning = true
@@ -371,6 +373,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         updateStatusItemTitle(timeRemaining: timerSettingSeconds)
 
         waitForNextSecond()
+    }
+
+    /**
+     Quick start a 25 minute timer
+
+     Called when the user clicks the Start 25 menu item.
+     */
+
+    @IBAction func start25(_ sender: AnyObject) {
+        Log.debug("start25 timer")
+        timerSettingSeconds = 25 * 60
+        internalStart()
     }
 
     /**

--- a/MenubarCountdown/MainMenu.xib
+++ b/MenubarCountdown/MainMenu.xib
@@ -14,6 +14,12 @@
         <customObject id="420" customClass="NSFontManager"/>
         <menu title="Menubar Countdown" id="450">
             <items>
+                <menuItem title="Start 25m" toolTip="Start a 25 minute countdown" id="Gxq-Wq-YcP">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="start25:" target="458" id="ZUc-jj-hH9"/>
+                    </connections>
+                </menuItem>
                 <menuItem title="Start…" toolTip="Start a countdown" id="451">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>


### PR DESCRIPTION
I like to be able to start a 25m timer without the extra clicks of going into the dialog.
Written to minimise the code changes so I didn't add services/scripting for start25.
